### PR TITLE
[Feature]: Search no longer resets when user navigates back. #688

### DIFF
--- a/src/routes/app/anime/[id]/+layout.svelte
+++ b/src/routes/app/anime/[id]/+layout.svelte
@@ -58,7 +58,7 @@
   }
 
   function goBack () {
-    window.history.back();
+    window.history.back()
   }
 
   $: mediaId = media.id
@@ -83,7 +83,7 @@
 <div class='min-w-0 -ml-14 pl-14 grow items-center flex flex-col h-full overflow-y-auto z-10 pointer-events-none pb-10' use:dragScroll on:scroll={handleScroll} bind:this={container} style:--custom={media.coverImage?.color ?? '#fff'} style:--red={r} style:--green={g} style:--blue={b}>
   <div class='gap-6 w-full pt-4 md:pt-32 flex flex-col items-center justify-center max-w-[1600px] px-3 xl:px-14 pointer-events-auto'>
     <div class='flex flex-col md:flex-row w-full items-center md:items-end gap-5 pt-12 relative'>
-      <button class="absolute top-0 left-0" on:click={goBack}>Go back</button>
+      <button class='absolute top-0 left-0' on:click={goBack}>Go back</button>
       <Dialog.Root portal='#root'>
         <Dialog.Trigger class='shrink-0 w-[180px] h-[256px] rounded overflow-hidden relative group focus-visible:ring-1 focus-visible:ring-ring select:scale-[1.02] transition-transform duration-200'>
           <div class='absolute flex-center w-full h-full bg-black group-select:bg-opacity-50 bg-opacity-0 duration-300 text-white transition-all ease-out'>

--- a/src/routes/app/anime/[id]/+layout.svelte
+++ b/src/routes/app/anime/[id]/+layout.svelte
@@ -57,6 +57,10 @@
     return 'bg-red-400 select:bg-red-500'
   }
 
+  function goBack () {
+    window.history.back();
+  }
+
   $: mediaId = media.id
   $: following = authAggregator.following(mediaId)
   $: followerEntries = $following?.data?.Page?.mediaList?.filter(e => e?.user?.id !== authAggregator.id()) ?? []
@@ -78,7 +82,8 @@
 
 <div class='min-w-0 -ml-14 pl-14 grow items-center flex flex-col h-full overflow-y-auto z-10 pointer-events-none pb-10' use:dragScroll on:scroll={handleScroll} bind:this={container} style:--custom={media.coverImage?.color ?? '#fff'} style:--red={r} style:--green={g} style:--blue={b}>
   <div class='gap-6 w-full pt-4 md:pt-32 flex flex-col items-center justify-center max-w-[1600px] px-3 xl:px-14 pointer-events-auto'>
-    <div class='flex flex-col md:flex-row w-full items-center md:items-end gap-5 pt-12'>
+    <div class='flex flex-col md:flex-row w-full items-center md:items-end gap-5 pt-12 relative'>
+      <button class="absolute top-0 left-0" on:click={goBack}>Go back</button>
       <Dialog.Root portal='#root'>
         <Dialog.Trigger class='shrink-0 w-[180px] h-[256px] rounded overflow-hidden relative group focus-visible:ring-1 focus-visible:ring-ring select:scale-[1.02] transition-transform duration-200'>
           <div class='absolute flex-center w-full h-full bg-black group-select:bg-opacity-50 bg-opacity-0 duration-300 text-white transition-all ease-out'>

--- a/src/routes/app/search/+page.svelte
+++ b/src/routes/app/search/+page.svelte
@@ -6,11 +6,12 @@
   import { onDestroy, tick } from 'svelte'
   import MagnifyingGlass from 'svelte-radix/MagnifyingGlass.svelte'
   import { toast } from 'svelte-sonner'
+
   import { genres, years, seasons, formats, status, sort, onlist } from './values'
 
   import type { Search } from '$lib/modules/anilist/queries'
-  import type { VariablesOf } from 'gql.tada'
   import type { Snapshot } from '../$types'
+  import type { VariablesOf } from 'gql.tada'
 
   import { replaceState } from '$app/navigation'
   import { page } from '$app/stores'
@@ -103,15 +104,15 @@
   export const snapshot: Snapshot = {
     capture: () => ({
       search: search,
-      inputText: inputText,
+      inputText: inputText
     }),
     restore: (value) => {
       if (value) {
-        search = value.search;
-        inputText = value.inputText;
+        search = value.search
+        inputText = value.inputText
       }
     }
-  };
+  }
 
   let pageNumber = 1
   let inputText = ''
@@ -137,7 +138,7 @@
     trace = undefined
   }
 
-  let media: Array<ReturnType<typeof client.search>> = [];
+  let media: Array<ReturnType<typeof client.search>> = []
 
   // these are required, because #each key re-renders when the array changes, this doesnt repaint the ui, but re-triggers any active subscriptions
   // and this re-runs the anilist queries as
@@ -147,9 +148,9 @@
 
   // handlers
 
-  function searchChanged(s: typeof search) {
-    pageNumber = 1;
-    media = [searchQuery(filterEmpty(s), 1)];
+  function searchChanged (s: typeof search) {
+    pageNumber = 1
+    media = [searchQuery(filterEmpty(s), 1)]
   }
 
   function searchQuery (filter: Partial<typeof search>, page: number) {
@@ -249,7 +250,7 @@
   let pressed = false
 </script>
 
-<div id="scroll" class='flex flex-col h-full overflow-y-auto overflow-x-clip -ml-14 pl-14 z-20 min-w-0 grow pointer-events-none' use:dragScroll use:infiniteScroll>
+<div id='scroll' class='flex flex-col h-full overflow-y-auto overflow-x-clip -ml-14 pl-14 z-20 min-w-0 grow pointer-events-none' use:dragScroll use:infiniteScroll>
   <div class='sticky top-0 z-20 px-2 sm:px-10 pointer-events-auto shrink-0 overflow-clip bg-black'>
     <div class='flex flex-wrap pt-5'>
       <div class='grid items-center min-w-44 flex-1 md:basis-auto md:w-1/4 p-2'>
@@ -334,9 +335,7 @@
         </button>
       {/each}
     </div>
-    
   </div>
-  
   <div class='flex flex-wrap md:px-7 justify-center pointer-events-auto'>
     {#each media as query, i (i)}
       {#if trace}

--- a/src/routes/app/search/+page.svelte
+++ b/src/routes/app/search/+page.svelte
@@ -6,11 +6,11 @@
   import { onDestroy, tick } from 'svelte'
   import MagnifyingGlass from 'svelte-radix/MagnifyingGlass.svelte'
   import { toast } from 'svelte-sonner'
-
   import { genres, years, seasons, formats, status, sort, onlist } from './values'
 
   import type { Search } from '$lib/modules/anilist/queries'
   import type { VariablesOf } from 'gql.tada'
+  import type { Snapshot } from '../$types'
 
   import { replaceState } from '$app/navigation'
   import { page } from '$app/stores'
@@ -98,6 +98,21 @@
     onList: [] as format[]
   }
 
+  // take a 'snapshot' of the latest search right before leaving the page
+  // latest search is restored if user clicks back
+  export const snapshot: Snapshot = {
+    capture: () => ({
+      search: search,
+      inputText: inputText,
+    }),
+    restore: (value) => {
+      if (value) {
+        search = value.search;
+        inputText = value.inputText;
+      }
+    }
+  };
+
   let pageNumber = 1
   let inputText = ''
 
@@ -122,7 +137,7 @@
     trace = undefined
   }
 
-  let media: Array<ReturnType<typeof client.search>> = []
+  let media: Array<ReturnType<typeof client.search>> = [];
 
   // these are required, because #each key re-renders when the array changes, this doesnt repaint the ui, but re-triggers any active subscriptions
   // and this re-runs the anilist queries as
@@ -132,9 +147,9 @@
 
   // handlers
 
-  function searchChanged (s: typeof search) {
-    pageNumber = 1
-    media = [searchQuery(filterEmpty(s), 1)]
+  function searchChanged(s: typeof search) {
+    pageNumber = 1;
+    media = [searchQuery(filterEmpty(s), 1)];
   }
 
   function searchQuery (filter: Partial<typeof search>, page: number) {
@@ -234,7 +249,7 @@
   let pressed = false
 </script>
 
-<div class='flex flex-col h-full overflow-y-auto overflow-x-clip -ml-14 pl-14 z-20 min-w-0 grow pointer-events-none' use:dragScroll use:infiniteScroll>
+<div id="scroll" class='flex flex-col h-full overflow-y-auto overflow-x-clip -ml-14 pl-14 z-20 min-w-0 grow pointer-events-none' use:dragScroll use:infiniteScroll>
   <div class='sticky top-0 z-20 px-2 sm:px-10 pointer-events-auto shrink-0 overflow-clip bg-black'>
     <div class='flex flex-wrap pt-5'>
       <div class='grid items-center min-w-44 flex-1 md:basis-auto md:w-1/4 p-2'>
@@ -319,7 +334,9 @@
         </button>
       {/each}
     </div>
+    
   </div>
+  
   <div class='flex flex-wrap md:px-7 justify-center pointer-events-auto'>
     {#each media as query, i (i)}
       {#if trace}
@@ -329,4 +346,5 @@
       {/if}
     {/each}
   </div>
+
 </div>


### PR DESCRIPTION
The user's search parameters aren't reset when navigating back from an anime. I did add a back button as well on the anime/[id] page but I heard that a back button is being added by you so I can remove it.

First time doing a pull request on GitHub so go easy *_*